### PR TITLE
Upgrade Actions node version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.16.1]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
The [deploy action](https://github.com/LBHackney-IT/housing-repairs-online/actions/runs/11464606511/job/31901177667\#step:5:11) failed because Docusaurus requires a modern node. 

This change bumps to the latest LTS, and uses a wildcard to select the latest minor/patch version.