### PR TITLE
Fix build by using GITHUB_TOKEN in deploy step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build page
         run: yarn run build
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
This is the 4th attempt to fix the build, each one uncovering a new issue. This time the [build failed](https://github.com/LBHackney-IT/housing-repairs-online/actions/runs/11500548576) with a permissions error:

```
Run peaceiris/actions-gh-pages@v3
[INFO] Usage https://github.com/peaceiris/actions-gh-pages#readme
Dump inputs
Setup auth token
Prepare publishing assets
Setup Git config
Create a commit
Push the commit or tag
  /usr/bin/git push origin gh-pages
  git@github.com: Permission denied (publickey).
  fatal: Could not read from remote repository.
  
  Please make sure you have the correct access rights
  and the repository exists.
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

I'm not sure when that secret disappeared or became invalid, but we can use the GitHub-managed `GITHUB_TOKEN` and not worry about it again.

While I'm at it, I've upgraded the GitHub Pages Action to latest – there are no breaking changes in their changelog other than moving to modern node.

This time!